### PR TITLE
feat: home page redirects to login and modules

### DIFF
--- a/frontend/src/lib/components/profile/Login.svelte
+++ b/frontend/src/lib/components/profile/Login.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import supabase from '$lib/supabase';
+
   let editOn = false;
 
   function toggleEdit() {
     editOn = !editOn;
   }
 
-  import supabase from '$lib/supabase';
   let loading = false;
   let email, password;
 
@@ -20,7 +21,7 @@
       if (error) throw error;
       alert('Successfully Logged In!');
 
-      location.href = '/account';
+      location.href = '/';
     } catch (error) {
       alert(error.error_description || error.message);
     } finally {

--- a/frontend/src/lib/userStore.ts
+++ b/frontend/src/lib/userStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const user = writable(false);

--- a/frontend/src/lib/userStore.ts
+++ b/frontend/src/lib/userStore.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const user = writable(false);

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -1,22 +1,22 @@
-<script context="module" lang="ts">
-  import { user } from '$lib/userStore';
+<script lang="ts">
+  import supabase from '$lib/supabase';
 
-  /** @type {import('@sveltejs/kit').Load} */ export function load() {
+  import type { User } from '@supabase/supabase-js';
+
+  async function redirectPage() {
     let redirect_url: string = '/login';
 
+    let user: User = supabase.auth.user();
+
+    console.log('after retrieving user in index:');
+    console.log(user);
+
     if (user) {
-      redirect_url = 'modules';
+      redirect_url = '/modules';
     }
 
-    return {
-      status: 302,
-      redirect: redirect_url
-    };
+    location.href = redirect_url;
   }
 </script>
 
-<script lang="ts">
-  import ModulePage from './modules.svelte';
-</script>
-
-<ModulePage />
+<div use:redirectPage />

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -1,3 +1,20 @@
+<script context="module" lang="ts">
+  import { user } from '$lib/userStore';
+
+  /** @type {import('@sveltejs/kit').Load} */ export function load() {
+    let redirect_url: string = '/login';
+
+    if (user) {
+      redirect_url = 'modules';
+    }
+
+    return {
+      status: 302,
+      redirect: redirect_url
+    };
+  }
+</script>
+
 <script lang="ts">
   import ModulePage from './modules.svelte';
 </script>


### PR DESCRIPTION
added logic for page redirection from `/index.svelte`:

- redirects to login page if a user is not logged in, 
- redirects to modules page if a user is logged in