### PR TITLE
feature: GET endpoints for all counsellors and all admins

### DIFF
--- a/src/routes/api/users/_api.ts
+++ b/src/routes/api/users/_api.ts
@@ -35,3 +35,22 @@ export async function userGET(
 
   return;
 }
+
+export async function typedUserGET(
+  user_type_name: 'counsellor' | 'admin'
+): Promise<user[] | undefined> {
+  const counsellors = await prisma.user_type.findMany({
+    where: {
+      name: user_type_name
+    },
+    select: {
+      user: true
+    }
+  });
+
+  if (counsellors) {
+    return removeBigInt(counsellors[0]['user']);
+  }
+
+  return;
+}

--- a/src/routes/api/users/admins/index.ts
+++ b/src/routes/api/users/admins/index.ts
@@ -1,0 +1,18 @@
+import { typedUserGET } from '../_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
+  const admins = await typedUserGET('admin');
+
+  if (admins) {
+    return {
+      status: 200,
+      headers: {},
+      body: admins
+    };
+  }
+
+  return {
+    status: 404
+  };
+}

--- a/src/routes/api/users/counsellors/index.ts
+++ b/src/routes/api/users/counsellors/index.ts
@@ -1,0 +1,18 @@
+import { typedUserGET } from '../_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
+  const counsellors = await typedUserGET('counsellor');
+
+  if (counsellors) {
+    return {
+      status: 200,
+      headers: {},
+      body: counsellors
+    };
+  }
+
+  return {
+    status: 404
+  };
+}


### PR DESCRIPTION
- added wrapper for user table query by user_type.name
- added GET endpoint for all counsellors at `/api/users/counsellors/`
- added GET endpoint for all admins at `/api/users/admins/`