### PR TITLE
feature: GET and POST endpoints for chatbot modules

### DIFF
--- a/src/lib/post_types.ts
+++ b/src/lib/post_types.ts
@@ -8,3 +8,8 @@ export type chatbot_attempt_message_POST = {
   text: string;
   message_type: 'user' | 'chatbot';
 };
+
+export type chatbot_module_POST = {
+  title: string;
+  description: string;
+};

--- a/src/routes/api/modules/chatbot/_api.ts
+++ b/src/routes/api/modules/chatbot/_api.ts
@@ -1,6 +1,7 @@
 import { chatbot_module } from '@prisma/client';
 import { prisma } from '../../../../lib/prisma';
 import { removeBigInt } from '../../../../lib/helpers';
+import { chatbot_module_POST } from '../../../../lib/post_types';
 
 type ChatbotModuleAPIGetParams = {
   id?: number;
@@ -28,6 +29,20 @@ export async function chatbotModuleGET(
 
   if (modules) {
     return removeBigInt(modules);
+  }
+
+  return;
+}
+
+export async function chatbotModulePOST(
+  new_module: chatbot_module_POST
+): Promise<chatbot_module | undefined> {
+  const created_module = await prisma.chatbot_module.create({
+    data: new_module
+  });
+
+  if (created_module) {
+    return created_module;
   }
 
   return;

--- a/src/routes/api/modules/chatbot/_api.ts
+++ b/src/routes/api/modules/chatbot/_api.ts
@@ -38,11 +38,14 @@ export async function chatbotModulePOST(
   new_module: chatbot_module_POST
 ): Promise<chatbot_module | undefined> {
   const created_module = await prisma.chatbot_module.create({
-    data: new_module
+    data: {
+      title: new_module.title,
+      description: new_module.description
+    }
   });
 
   if (created_module) {
-    return created_module;
+    return removeBigInt(created_module);
   }
 
   return;

--- a/src/routes/api/modules/chatbot/_api.ts
+++ b/src/routes/api/modules/chatbot/_api.ts
@@ -1,6 +1,6 @@
 import { chatbot_module } from '@prisma/client';
-import { prisma } from '../../../lib/prisma';
-import { removeBigInt } from '../../../lib/helpers';
+import { prisma } from '../../../../lib/prisma';
+import { removeBigInt } from '../../../../lib/helpers';
 
 type ChatbotModuleAPIGetParams = {
   id?: number;

--- a/src/routes/api/modules/chatbot/index.ts
+++ b/src/routes/api/modules/chatbot/index.ts
@@ -1,4 +1,6 @@
-import { chatbotModuleGET } from './_api';
+import { chatbot_module } from '@prisma/client';
+import { chatbot_module_POST } from '../../../../lib/post_types';
+import { chatbotModuleGET, chatbotModulePOST } from './_api';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function GET() {
@@ -14,5 +16,26 @@ export async function GET() {
 
   return {
     status: 404
+  };
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function POST({ request }) {
+  const new_module: chatbot_module_POST = await request.json();
+
+  const created_module: chatbot_module | undefined = await chatbotModulePOST(
+    new_module
+  );
+
+  if (created_module) {
+    return {
+      status: 200,
+      headers: {},
+      body: created_module
+    };
+  }
+
+  return {
+    status: 400
   };
 }

--- a/src/routes/api/modules/chatbot/index.ts
+++ b/src/routes/api/modules/chatbot/index.ts
@@ -1,0 +1,18 @@
+import { chatbotModuleGET } from './_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
+  const modules = await chatbotModuleGET();
+
+  if (modules) {
+    return {
+      status: 200,
+      headers: {},
+      body: modules
+    };
+  }
+
+  return {
+    status: 404
+  };
+}

--- a/src/routes/prisma-example/creation-example.svelte
+++ b/src/routes/prisma-example/creation-example.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type {
     chatbot_attempt_message_POST,
-    chatbot_attempt_POST
+    chatbot_attempt_POST,
+    chatbot_module_POST
   } from '$lib/post_types';
 
   async function handleClick() {
@@ -18,6 +19,11 @@
       cbm_id: 1
     };
 
+    const module: chatbot_module_POST = {
+      title: 'Sample title!',
+      description: `Sample description created at ${creation_time.toLocaleTimeString()}`
+    };
+
     const message_result = await fetch('/api/chatbot-messages', {
       method: 'POST',
       body: JSON.stringify(message)
@@ -28,9 +34,16 @@
       body: JSON.stringify(attempt)
     });
 
+    const module_result = await fetch('/api/modules/chatbot', {
+      method: 'POST',
+      body: JSON.stringify(module)
+    });
+
     console.log(await message_result.json());
 
     console.log(await attempt_result.json());
+
+    console.log(await module_result.json());
   }
 </script>
 


### PR DESCRIPTION
- changed specific endpoint from `/api/chatbot-modules/` to more general `/api/modules/chatbot/`
- added GET endpoint for all modules at `/api/modules/chatbot/`
- created new chatbot_module_POST type
- created wrapper for DB chatbot module creation
- added POST endpoint at `/api/modules/chatbot/`
- renamed `/prisma-example/create-message-example.svelte` to `/prisma-example/creation-example.svelte`
- added module creation example to `/prisma-example/creation-example.svelte`