### PR TITLE
fix: stable sveltekit version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
-        "@sveltejs/kit": "next",
+        "@sveltejs/kit": "1.0.0-next.403",
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/svelte": "^3.1.0",
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "next",
-    "@sveltejs/kit": "next",
+    "@sveltejs/kit": "1.0.0-next.403",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/svelte": "^3.1.0",
     "@types/jest": "^27.4.1",


### PR DESCRIPTION
We were encountering an issue with mismatched sveltekit versions causing error across different teammates' local repos. This should hopefully fix these problems.

- set the version of sveltekit in `package-lock.json` to "1.0.0-next.403" rather than "next"