### PR TITLE
feat: add id specific GET endpoint for chatbot modules

### DIFF
--- a/src/routes/api/modules/chatbot/[module_id].ts
+++ b/src/routes/api/modules/chatbot/[module_id].ts
@@ -1,0 +1,19 @@
+import { chatbot_module } from '@prisma/client';
+import { chatbotModuleGET } from './_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET({ params }) {
+  const modules = await chatbotModuleGET({ id: parseInt(params.module_id) });
+
+  if (modules) {
+    return {
+      status: 200,
+      headers: {},
+      body: modules
+    };
+  }
+
+  return {
+    status: 404
+  };
+}


### PR DESCRIPTION
- create id-specific GET endpoint at `/api/modules/chatbot/[module_id]`