### PR TITLE
feat: chatbot assignments PATCH endpoint

### DIFF
--- a/src/lib/patch_types.ts
+++ b/src/lib/patch_types.ts
@@ -1,6 +1,7 @@
 export type chatbot_assignment_PATCH = {
   cbm_id: number;
   user_id: number;
+  created_at: Date;
   duedate?: Date;
   completed_at?: Date;
   completed?: boolean;

--- a/src/lib/patch_types.ts
+++ b/src/lib/patch_types.ts
@@ -1,0 +1,8 @@
+export type chatbot_assignment_PATCH = {
+  cbm_id: number;
+  user_id: number;
+  duedate?: Date;
+  completed_at?: Date;
+  completed?: boolean;
+  attempt_id?: number;
+};

--- a/src/routes/api/chatbot-assignments/_api.ts
+++ b/src/routes/api/chatbot-assignments/_api.ts
@@ -2,6 +2,7 @@ import { chatbot_assignment } from '@prisma/client';
 import { prisma } from '../../../lib/prisma';
 import { removeBigInt } from '../../../lib/helpers';
 import { chatbot_assignment_POST } from '../../../lib/post_types';
+import { chatbot_assignment_PATCH } from '../../../lib/patch_types';
 
 type ChatbotAssignmentsAPIGetParams = {
   user_id: number;
@@ -65,6 +66,38 @@ export async function moduleSpecificAssignmentGET(
 
   if (assignments) {
     return removeBigInt(assignments);
+  }
+
+  return;
+}
+
+export async function chatbotAssignmentsPATCH(
+  modified_assignment: chatbot_assignment_PATCH
+): Promise<chatbot_assignment | undefined> {
+  const find_params = {
+    cbm_id: BigInt(modified_assignment.cbm_id),
+    user_id: BigInt(modified_assignment.user_id),
+    created_at: modified_assignment.created_at
+  };
+
+  const update_params = {
+    duedate: modified_assignment.duedate,
+    completed_at: modified_assignment.completed_at,
+    completed: modified_assignment.completed,
+    attempt_id: modified_assignment.attempt_id
+      ? BigInt(modified_assignment.attempt_id)
+      : undefined
+  };
+
+  const assignment = await prisma.chatbot_assignment.update({
+    where: {
+      cbm_id_user_id_created_at: find_params
+    },
+    data: update_params
+  });
+
+  if (assignment) {
+    return removeBigInt(assignment);
   }
 
   return;

--- a/src/routes/api/chatbot-assignments/index.ts
+++ b/src/routes/api/chatbot-assignments/index.ts
@@ -1,6 +1,7 @@
 import { chatbot_assignment } from '@prisma/client';
+import { chatbot_assignment_PATCH } from '../../../lib/patch_types';
 import { chatbot_assignment_POST } from '../../../lib/post_types';
-import { chatbotAssignmentsPOST } from './_api';
+import { chatbotAssignmentsPOST, chatbotAssignmentsPATCH } from './_api';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function POST({ request }) {
@@ -14,6 +15,28 @@ export async function POST({ request }) {
       status: 200,
       headers: {},
       body: created_assignment
+    };
+  }
+
+  return {
+    status: 400
+  };
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function PATCH({ request }) {
+  const modified_assignment: chatbot_assignment_PATCH = await request.json();
+
+  const confirmed_assignment: chatbot_assignment | undefined =
+    await chatbotAssignmentsPATCH(modified_assignment);
+
+  console.log(confirmed_assignment);
+
+  if (confirmed_assignment) {
+    return {
+      status: 200,
+      headers: {},
+      body: confirmed_assignment
     };
   }
 

--- a/src/routes/api/chatbot-assignments/index.ts
+++ b/src/routes/api/chatbot-assignments/index.ts
@@ -30,8 +30,6 @@ export async function PATCH({ request }) {
   const confirmed_assignment: chatbot_assignment | undefined =
     await chatbotAssignmentsPATCH(modified_assignment);
 
-  console.log(confirmed_assignment);
-
   if (confirmed_assignment) {
     return {
       status: 200,

--- a/src/routes/prisma-example/creation-example.svelte
+++ b/src/routes/prisma-example/creation-example.svelte
@@ -5,6 +5,10 @@
     chatbot_module_POST
   } from '$lib/post_types';
 
+  import type { chatbot_assignment_PATCH } from '$lib/patch_types';
+
+  import type { chatbot_assignment } from '@prisma/client';
+
   async function handleClick() {
     const creation_time = new Date();
 
@@ -45,8 +49,43 @@
 
     console.log(await module_result.json());
   }
+
+  async function handlePATCHClick() {
+    // grab an existing assignment
+    let old_assignment = await (
+      await (await fetch('/api/chatbot-assignments/user_id=35')).json()
+    )[0];
+
+    console.log('old assignment');
+    console.log(old_assignment);
+
+    // modify it a bit
+    const changed_assignment: chatbot_assignment_PATCH = {
+      cbm_id: old_assignment.cbm_id,
+      user_id: old_assignment.user_id,
+      created_at: old_assignment.created_at,
+      completed_at: new Date(),
+      completed: true,
+      attempt_id: 183
+    };
+
+    // throw it to the patch endpoint
+    const modified_assignment: chatbot_assignment = await (
+      await fetch('/api/chatbot-assignments', {
+        method: 'PATCH',
+        body: JSON.stringify(changed_assignment)
+      })
+    ).json();
+
+    console.log('modified assignment');
+    console.log(modified_assignment);
+  }
 </script>
 
 <button on:click={handleClick}>
   Click to send a new message (and a new attempt!)
+</button>
+
+<button on:click={handlePATCHClick}>
+  Click to update an assignment record!
 </button>


### PR DESCRIPTION
- add new `chatbot_assignment_PATCH` type
- add PATCH endpoint at `/api/chatbot_assignments`
- add PATCH example in `/src/routes/prisma-example/creation-example.svelte`