### PR TITLE
fix: landing page tile typo

### DIFF
--- a/src/lib/components/LandingPageTile.svelte
+++ b/src/lib/components/LandingPageTile.svelte
@@ -2,14 +2,15 @@
   export let imgUrl =
     'https://api.lorem.space/image/furniture?w=400&h=225&hash=33751';
   export let trainingType = '';
-  export let path = '/dashboard'
-  export let description = ""
+  export let path = '/dashboard';
+  export let description = '';
 </script>
 
 <div>
   <a
-  class="bg-gray-100 text-gray-800 text-center rounded-md flex flex-col items-center"
-  href={path}>
+    class="bg-gray-100 text-gray-800 text-center rounded-md flex flex-col items-center"
+    href={path}
+  >
     <img class="rounded-md col-span-1" src={imgUrl} alt="Module" />
     <div class="mb-2">
       <b>


### PR DESCRIPTION
Renamed `landingPageTile.svelte` to `LandingPageTile.svelte` so it
- matches other component naming convention
- stops breaking import in `/src/routes/landing-page.svelte`