### PR TITLE
feat: learning outcomes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,11 +57,12 @@ model chatbot_attempt_message {
 }
 
 model chatbot_module {
-  id                 BigInt               @id @default(autoincrement())
-  title              String               @db.VarChar
-  description        String
-  chatbot_assignment chatbot_assignment[]
-  chatbot_attempt    chatbot_attempt[]
+  id                              BigInt                            @id @default(autoincrement())
+  title                           String                            @db.VarChar
+  description                     String
+  chatbot_assignment              chatbot_assignment[]
+  chatbot_attempt                 chatbot_attempt[]
+  chatbot_module_learning_outcome chatbot_module_learning_outcome[]
 }
 
 model forum_post {
@@ -130,4 +131,21 @@ model message_type {
   id                      BigInt                    @id @default(autoincrement())
   name                    String                    @unique @db.VarChar
   chatbot_attempt_message chatbot_attempt_message[]
+}
+
+model chatbot_module_learning_outcome {
+  cbm_id              BigInt
+  learning_outcome_id BigInt
+  created_at          DateTime?        @default(now()) @db.Timestamptz(6)
+  chatbot_module      chatbot_module   @relation(fields: [cbm_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  learning_outcome    learning_outcome @relation(fields: [learning_outcome_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@id([cbm_id, learning_outcome_id])
+}
+
+model learning_outcome {
+  id                              BigInt                            @id @default(autoincrement())
+  created_at                      DateTime?                         @default(now()) @db.Timestamptz(6)
+  description                     String                            @unique @db.VarChar
+  chatbot_module_learning_outcome chatbot_module_learning_outcome[]
 }

--- a/src/routes/api/learning-outcomes/_api.ts
+++ b/src/routes/api/learning-outcomes/_api.ts
@@ -1,0 +1,32 @@
+import { learning_outcome } from '@prisma/client';
+import { prisma } from '../../../lib/prisma';
+import { removeBigInt } from '../../../lib/helpers';
+
+export async function moduleSpecificLearningOutcomesGET(
+  module_id: number
+): Promise<learning_outcome[] | undefined> {
+  const learning_outcomes =
+    await prisma.chatbot_module_learning_outcome.findMany({
+      where: {
+        cbm_id: module_id
+      },
+      select: {
+        learning_outcome: {
+          select: {
+            id: true,
+            description: true
+          }
+        }
+      }
+    });
+
+  if (learning_outcomes) {
+    const outcomes = learning_outcomes.map((elem) => {
+      return elem['learning_outcome'];
+    });
+
+    return removeBigInt(outcomes);
+  }
+
+  return;
+}

--- a/src/routes/api/learning-outcomes/module_id=[module_id].ts
+++ b/src/routes/api/learning-outcomes/module_id=[module_id].ts
@@ -1,0 +1,20 @@
+import { learning_outcome } from '@prisma/client';
+import { moduleSpecificLearningOutcomesGET } from './_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET({ params }) {
+  const learning_outcomes: learning_outcome[] | undefined =
+    await moduleSpecificLearningOutcomesGET(parseInt(params.module_id));
+
+  if (learning_outcomes) {
+    return {
+      status: 200,
+      headers: {},
+      body: learning_outcomes
+    };
+  }
+
+  return {
+    status: 404
+  };
+}

--- a/src/routes/api/modules/chatbot/_api.ts
+++ b/src/routes/api/modules/chatbot/_api.ts
@@ -14,11 +14,36 @@ export async function chatbotModuleGET(
   let modules: chatbot_module[] = [];
 
   if (!params) {
-    modules = await prisma.chatbot_module.findMany();
+    modules = await prisma.chatbot_module.findMany({
+      include: {
+        chatbot_module_learning_outcome: {
+          include: {
+            learning_outcome: {
+              select: {
+                id: true,
+                description: true
+              }
+            }
+          }
+        }
+      }
+    });
   } else {
     const foundModule = await prisma.chatbot_module.findUnique({
       where: {
         id: params.id
+      },
+      include: {
+        chatbot_module_learning_outcome: {
+          include: {
+            learning_outcome: {
+              select: {
+                id: true,
+                description: true
+              }
+            }
+          }
+        }
       }
     });
 


### PR DESCRIPTION
- added learning_outcome and chatbot_module_learning_outcome tables to db
- updated prisma schema by introspecting db
- added learning outcomes to return of `/api/modules/chatbot/` endpoint
- added module-specific GET endpoint for learning outcomes at `/api/learning-outcomes/module_id=[module_id]`