### PR TITLE
feat: forum post api

### DIFF
--- a/src/lib/post_types.ts
+++ b/src/lib/post_types.ts
@@ -19,3 +19,9 @@ export type chatbot_module_POST = {
   title: string;
   description: string;
 };
+
+export type forum_post_module_POST = {
+  text: string;
+  username: string;
+  valid: boolean;
+};

--- a/src/lib/post_types.ts
+++ b/src/lib/post_types.ts
@@ -20,7 +20,7 @@ export type chatbot_module_POST = {
   description: string;
 };
 
-export type forum_post_module_POST = {
+export type forum_post_POST = {
   text: string;
   username: string;
   valid: boolean;

--- a/src/routes/api/modules/forum-post/[id].ts
+++ b/src/routes/api/modules/forum-post/[id].ts
@@ -1,0 +1,20 @@
+import { forumPostGET } from './_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET({ params }) {
+  const post = await forumPostGET({
+    id: parseInt(params.id)
+  });
+
+  if (post) {
+    return {
+      status: 200,
+      headers: {},
+      body: post
+    };
+  }
+
+  return {
+    status: 404
+  };
+}

--- a/src/routes/api/modules/forum-post/_api.ts
+++ b/src/routes/api/modules/forum-post/_api.ts
@@ -1,0 +1,52 @@
+import { forum_post } from '@prisma/client';
+import { prisma } from '../../../../lib/prisma';
+import { removeBigInt } from '../../../../lib/helpers';
+import { forum_post_POST } from '../../../../lib/post_types';
+
+type ForumPostAPIGetParams = {
+  id?: number;
+};
+
+export async function forumPostGET(
+  params?: ForumPostAPIGetParams
+): Promise<forum_post[] | undefined> {
+  let posts: forum_post[] = [];
+
+  if (!params) {
+    posts = await prisma.forum_post.findMany();
+  } else {
+    const foundModule = await prisma.forum_post.findUnique({
+      where: {
+        id: params.id
+      }
+    });
+
+    if (foundModule) {
+      posts = removeBigInt(foundModule);
+    }
+  }
+
+  if (posts) {
+    return removeBigInt(posts);
+  }
+
+  return;
+}
+
+export async function forumPostPOST(
+  new_post: forum_post_POST
+): Promise<forum_post | undefined> {
+  const created_module = await prisma.forum_post.create({
+    data: {
+      text: new_post.text,
+      username: new_post.username,
+      valid: new_post.valid
+    }
+  });
+
+  if (created_module) {
+    return removeBigInt(created_module);
+  }
+
+  return;
+}

--- a/src/routes/api/modules/forum-post/index.ts
+++ b/src/routes/api/modules/forum-post/index.ts
@@ -1,0 +1,41 @@
+import { forum_post } from '@prisma/client';
+import { forum_post_POST } from '../../../../lib/post_types';
+import { forumPostGET, forumPostPOST } from './_api';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
+  const modules = await forumPostGET();
+
+  if (modules) {
+    return {
+      status: 200,
+      headers: {},
+      body: modules
+    };
+  }
+
+  return {
+    status: 404
+  };
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function POST({ request }) {
+  const new_module: forum_post_POST = await request.json();
+
+  const created_module: forum_post | undefined = await forumPostPOST(
+    new_module
+  );
+
+  if (created_module) {
+    return {
+      status: 200,
+      headers: {},
+      body: created_module
+    };
+  }
+
+  return {
+    status: 400
+  };
+}

--- a/src/routes/prisma-example/creation-example.svelte
+++ b/src/routes/prisma-example/creation-example.svelte
@@ -2,7 +2,8 @@
   import type {
     chatbot_attempt_message_POST,
     chatbot_attempt_POST,
-    chatbot_module_POST
+    chatbot_module_POST,
+    forum_post_POST
   } from '$lib/post_types';
 
   import type { chatbot_assignment_PATCH } from '$lib/patch_types';
@@ -28,6 +29,12 @@
       description: `Sample description created at ${creation_time.toLocaleTimeString()}`
     };
 
+    const forum_post: forum_post_POST = {
+      text: `example forum post created at ${creation_time.toLocaleTimeString()}`,
+      username: 'example@test.com',
+      valid: false
+    };
+
     const message_result = await fetch('/api/chatbot-messages', {
       method: 'POST',
       body: JSON.stringify(message)
@@ -43,11 +50,18 @@
       body: JSON.stringify(module)
     });
 
+    const forum_post_result = await fetch('/api/modules/forum-post', {
+      method: 'POST',
+      body: JSON.stringify(forum_post)
+    });
+
     console.log(await message_result.json());
 
     console.log(await attempt_result.json());
 
     console.log(await module_result.json());
+
+    console.log(await forum_post_result.json());
   }
 
   async function handlePATCHClick() {


### PR DESCRIPTION
- add new forum_post_POST type
- add GET and POST methods at `/api/modules/forum-post/`
- add module id-specific GET endpoint at `/api/modules/forum-post/[id]`
- add forum post creation example in `/prisma-example/creation-example.svelte`